### PR TITLE
Optimization 1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
 
     // LibMultiPart dependency
     val lmpVersion: String by project
-    modCompileOnly("alexiil.mc.lib:libmultipart-all:$lmpVersion") {
+    modImplementation("alexiil.mc.lib:libmultipart-all:$lmpVersion") {
         exclude("net.fabricmc.fabric-api")
     }
     // JIJs LMP, LNS, & LBA Core

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
 
     // LibMultiPart dependency
     val lmpVersion: String by project
-    modImplementation("alexiil.mc.lib:libmultipart-all:$lmpVersion") {
+    modCompileOnly("alexiil.mc.lib:libmultipart-all:$lmpVersion") {
         exclude("net.fabricmc.fabric-api")
     }
     // JIJs LMP, LNS, & LBA Core

--- a/src/main/kotlin/com/kneelawk/wiredredstone/part/GateDiodePart.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/part/GateDiodePart.kt
@@ -157,7 +157,7 @@ class GateDiodePart : AbstractRotatedPart {
 
     private fun getRedstoneOutputPower(powerSide: Direction): Int {
         val edge = RotationUtils.rotatedDirection(side, direction)
-        return if (RedstoneLogic.wiresGivePower && powerSide == edge) getTotalOutputPower() else 0
+        return if (RedstoneLogic.wiresGivePower && powerSide == edge) outputPower else 0
     }
 
     fun getTotalOutputPower(): Int {
@@ -224,8 +224,8 @@ class GateDiodePart : AbstractRotatedPart {
         redraw()
         getBlockEntity().markDirty()
 
-        val edge = RotationUtils.rotatedDirection(side, direction)
-        WorldUtils.strongUpdateNeighbors(getWorld(), getPos(), edge)
+//        val edge = RotationUtils.rotatedDirection(side, direction)
+//        WorldUtils.strongUpdateNeighbors(getWorld(), getPos(), edge)
     }
 
     fun updateInputPower(power: Int) {

--- a/src/main/kotlin/com/kneelawk/wiredredstone/part/RedrawablePart.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/part/RedrawablePart.kt
@@ -2,4 +2,6 @@ package com.kneelawk.wiredredstone.part
 
 interface RedrawablePart {
     fun redraw()
+
+    fun recalculateShape()
 }

--- a/src/main/kotlin/com/kneelawk/wiredredstone/util/ConnectableUtils.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/util/ConnectableUtils.kt
@@ -17,21 +17,6 @@ import net.minecraft.util.shape.VoxelShape
 import net.minecraft.world.BlockView
 
 object ConnectableUtils {
-    data class Connection(val edge: Direction, val type: ConnectionType) {
-        fun setForSide(side: Direction, connections: UByte, blockage: UByte = BlockageUtils.UNBLOCKED): UByte {
-            val cardinal = RotationUtils.unrotatedDirection(side, edge)
-            if (!DirectionUtils.isHorizontal(cardinal) || BlockageUtils.isBlocked(blockage, cardinal)) {
-                // A blockage or a vertical connection means we shouldn't set anything
-                return connections
-            }
-
-            return when (type) {
-                ConnectionType.INTERNAL -> ConnectionUtils.setInternal(connections, cardinal)
-                ConnectionType.EXTERNAL -> ConnectionUtils.setExternal(connections, cardinal)
-                ConnectionType.CORNER -> ConnectionUtils.setCorner(connections, cardinal)
-            }
-        }
-    }
 
     /**
      * Updates both the connections and the blockage of the LMP part and asks it to update the client.
@@ -112,7 +97,10 @@ object ConnectableUtils {
         val newConnections = part.overrideConnections(connections.first)
 
         part.updateConnections(newConnections)
-        (part as? RedrawablePart)?.redraw()
+        (part as? RedrawablePart)?.let {
+            it.redraw()
+            it.recalculateShape()
+        }
     }
 
     private inline fun setSingularConnection(
@@ -132,6 +120,31 @@ object ConnectableUtils {
             Pair(ConnectionUtils.setDisconnected(connections.first, cardinal), connections.second)
         } else {
             Pair(set(connections.first, cardinal), set(connections.second, cardinal))
+        }
+    }
+
+    fun shouldUpdateConnectionsForNeighborUpdate(
+        shapeCache: MutableMap<Direction, VoxelShape>, world: ServerWorld, yourPos: BlockPos, otherPos: BlockPos
+    ): Boolean {
+        val direction = Direction.fromVector(otherPos.subtract(yourPos))
+        return if (direction != null) {
+            val previousShape = shapeCache[direction]
+            val state = world.getBlockState(otherPos)
+            val curShape = state.getOutlineShape(world, otherPos)
+
+            if (previousShape != null) {
+                // Identity checking here is about the best we can do if we want to be fast. This works because most
+                // blocks re-use the same VoxelShape objects if they want to keep their shapes.
+                if (previousShape !== curShape) {
+                    shapeCache[direction] = curShape
+                    true
+                } else false
+            } else {
+                shapeCache[direction] = curShape
+                true
+            }
+        } else {
+            true
         }
     }
 

--- a/src/main/kotlin/com/kneelawk/wiredredstone/wirenet/Network.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/wirenet/Network.kt
@@ -1,6 +1,6 @@
 package com.kneelawk.wiredredstone.wirenet
 
-import com.google.common.collect.HashMultimap
+import com.google.common.collect.LinkedHashMultimap
 import com.kneelawk.wiredredstone.util.SidedPos
 import net.fabricmc.fabric.api.util.NbtType
 import net.minecraft.nbt.NbtCompound
@@ -47,7 +47,7 @@ class Network(val controller: WireNetworkController, val id: UUID) {
 
     private val graph = NetGraph()
 
-    private val nodesInPos = HashMultimap.create<BlockPos, NetNode>()
+    private val nodesInPos = LinkedHashMultimap.create<BlockPos, NetNode>()
 
     fun toTag(tag: NbtCompound): NbtCompound {
         val serializedNodes = mutableListOf<NbtCompound>()
@@ -70,10 +70,10 @@ class Network(val controller: WireNetworkController, val id: UUID) {
         return tag
     }
 
-    fun getNodesAt(pos: BlockPos) = nodesInPos[pos].toSet()
+    fun getNodesAt(pos: BlockPos): Sequence<NetNode> = nodesInPos[pos].asSequence()
 
-    fun getNodesAt(pos: SidedPos) =
-        nodesInPos[pos.pos].filter { it.data.ext is SidedPartExt && it.data.ext.side == pos.side }.toSet()
+    fun getNodesAt(pos: SidedPos): Sequence<NetNode> =
+        nodesInPos[pos.pos].asSequence().filter { it.data.ext is SidedPartExt && it.data.ext.side == pos.side }
 
     fun getNodes() = graph.nodes
 

--- a/src/main/kotlin/com/kneelawk/wiredredstone/wirenet/NodeView.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/wirenet/NodeView.kt
@@ -9,7 +9,7 @@ import net.minecraft.util.math.BlockPos
 class NodeView(world: ServerWorld) {
     private val wns = world.getWireNetworkState()
 
-    fun getNodes(pos: SidedPos): Set<NetNode> = wns.controller.getNodesAt(pos)
+    fun getNodes(pos: SidedPos): Sequence<NetNode> = wns.controller.getNodesAt(pos)
 
-    fun getNodes(pos: BlockPos): Set<NetNode> = wns.controller.getNodesAt(pos)
+    fun getNodes(pos: BlockPos): Sequence<NetNode> = wns.controller.getNodesAt(pos)
 }

--- a/src/main/kotlin/com/kneelawk/wiredredstone/wirenet/conn/ConnectionDiscoverers.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/wirenet/conn/ConnectionDiscoverers.kt
@@ -13,7 +13,7 @@ object ConnectionDiscoverers {
     val WIRE = connectionDiscoverer<ConnectablePartExt, Direction> {
         // wires in same block
         connectionRule {
-            forOutputs { Direction.values().filter { it.axis != self.data.ext.side.axis } }
+            forOutputs { Direction.values().asSequence().filter { it.axis != self.data.ext.side.axis } }
             connect {
                 findNode(pos, Constraint(ConnectablePartExt::class) { otherNode ->
                     val other = otherNode.data.ext
@@ -24,7 +24,7 @@ object ConnectionDiscoverers {
 
         // planar connections
         connectionRule {
-            forOutputs { Direction.values().filter { it.axis != self.data.ext.side.axis } }
+            forOutputs { Direction.values().asSequence().filter { it.axis != self.data.ext.side.axis } }
             connect {
                 val otherPos = pos.offset(output)
                 findNode(otherPos, Constraint(ConnectablePartExt::class) { otherNode ->
@@ -36,7 +36,7 @@ object ConnectionDiscoverers {
 
         // machine connections
         connectionRule {
-            forOutputs { Direction.values().filter { it != self.data.ext.side.opposite } }
+            forOutputs { Direction.values().asSequence().filter { it != self.data.ext.side.opposite } }
             connect {
                 findNode(pos.offset(output), Constraint(FullBlockPartExt::class))
             }
@@ -44,7 +44,7 @@ object ConnectionDiscoverers {
 
         // corner connections
         connectionRule {
-            forOutputs { Direction.values().filter { it.axis != self.data.ext.side.axis } }
+            forOutputs { Direction.values().asSequence().filter { it.axis != self.data.ext.side.axis } }
             connect {
                 val otherPos = pos.offset(output).offset(self.data.ext.side)
                 findNode(otherPos, Constraint(ConnectablePartExt::class) { otherNode ->
@@ -65,14 +65,14 @@ object ConnectionDiscoverers {
 
     val FULL_BLOCK = connectionDiscoverer<FullBlockPartExt, Edge> {
         connectionRule {
-            forOutputs { edges }
+            forOutputs { edges.asSequence() }
             connect {
                 findNode(pos.offset(output.side), Constraint(ConnectablePartExt::class) { it.data.ext.side == output.edge })
             }
         }
 
         connectionRule {
-            forOutputs { edges }
+            forOutputs { edges.asSequence() }
             connect {
                 findNode(
                     pos.offset(output.side), Constraint(FullBlockPartExt::class)
@@ -88,7 +88,7 @@ object ConnectionDiscoverers {
 
     private fun <E : PartExt, T> ConnectScope<E, T>.findNode(
         at: BlockPos, vararg constraints: Constraint<*>
-    ): List<NetNode> {
+    ): Sequence<NetNode> {
         return nv.getNodes(at).filter { node -> constraints.all { c -> c.matches(node) } }
     }
 }


### PR DESCRIPTION
# This PR
This pr provides several significant optimizations, mainly:
 * Diodes cause less block-updates.
 * Connection-recalculation is more efficient.
 * Network ref-rebuilds are more efficient.
 * Network connection attempts are more efficient.
 * Block-updates only cause network connection updates if the updating block's outline has changed.
 * Reduce the frequency of parts' outline-shape recalculations.

# Testing
I have tested this PR in two different redstone worlds and have found server tick times, that were previously unacceptably high, returning to acceptable levels. Previously I was seeing tick-times of 15 to 30ms, now tick times are 2 to 14ms.