### PR TITLE
Use Framebuffers for Rendering Gate Text Overlays

### DIFF
--- a/src/main/java/com/kneelawk/wiredredstone/mixin/api/FramebufferHelper.java
+++ b/src/main/java/com/kneelawk/wiredredstone/mixin/api/FramebufferHelper.java
@@ -1,0 +1,10 @@
+package com.kneelawk.wiredredstone.mixin.api;
+
+import com.kneelawk.wiredredstone.mixin.impl.FramebufferAccessor;
+import net.minecraft.client.gl.Framebuffer;
+
+public class FramebufferHelper {
+    public static int getColorAttachment(Framebuffer fb) {
+        return ((FramebufferAccessor) fb).getColorAttachment();
+    }
+}

--- a/src/main/java/com/kneelawk/wiredredstone/mixin/impl/FramebufferAccessor.java
+++ b/src/main/java/com/kneelawk/wiredredstone/mixin/impl/FramebufferAccessor.java
@@ -1,0 +1,11 @@
+package com.kneelawk.wiredredstone.mixin.impl;
+
+import net.minecraft.client.gl.Framebuffer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Framebuffer.class)
+public interface FramebufferAccessor {
+    @Accessor()
+    int getColorAttachment();
+}

--- a/src/main/kotlin/com/kneelawk/wiredredstone/client/render/FramebufferTexture.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/client/render/FramebufferTexture.kt
@@ -3,6 +3,7 @@ package com.kneelawk.wiredredstone.client.render
 import com.kneelawk.wiredredstone.mixin.api.FramebufferHelper
 import net.minecraft.client.gl.Framebuffer
 import net.minecraft.client.texture.AbstractTexture
+import net.minecraft.client.texture.MissingSprite
 import net.minecraft.resource.ResourceManager
 
 class FramebufferTexture(val fb: Framebuffer) : AbstractTexture() {
@@ -11,7 +12,13 @@ class FramebufferTexture(val fb: Framebuffer) : AbstractTexture() {
     }
 
     override fun getGlId(): Int {
-        return FramebufferHelper.getColorAttachment(fb)
+        val id = FramebufferHelper.getColorAttachment(fb)
+
+        if (id < 0) {
+            return MissingSprite.getMissingSpriteTexture().glId
+        }
+
+        return id
     }
 
     override fun clearGlId() {

--- a/src/main/kotlin/com/kneelawk/wiredredstone/client/render/FramebufferTexture.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/client/render/FramebufferTexture.kt
@@ -1,0 +1,24 @@
+package com.kneelawk.wiredredstone.client.render
+
+import com.kneelawk.wiredredstone.mixin.api.FramebufferHelper
+import net.minecraft.client.gl.Framebuffer
+import net.minecraft.client.texture.AbstractTexture
+import net.minecraft.resource.ResourceManager
+
+class FramebufferTexture(val fb: Framebuffer) : AbstractTexture() {
+    override fun load(manager: ResourceManager) {
+        // NO-OP
+    }
+
+    override fun getGlId(): Int {
+        return FramebufferHelper.getColorAttachment(fb)
+    }
+
+    override fun clearGlId() {
+        // NO-OP
+    }
+
+    override fun close() {
+        fb.delete()
+    }
+}

--- a/src/main/kotlin/com/kneelawk/wiredredstone/client/render/RenderUtils.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/client/render/RenderUtils.kt
@@ -10,7 +10,6 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView
 import net.minecraft.client.MinecraftClient
-import net.minecraft.client.font.TextRenderer
 import net.minecraft.client.render.OverlayTexture
 import net.minecraft.client.render.VertexConsumer
 import net.minecraft.client.render.VertexConsumerProvider
@@ -18,7 +17,7 @@ import net.minecraft.client.render.model.BakedModel
 import net.minecraft.client.texture.Sprite
 import net.minecraft.client.texture.SpriteAtlasTexture
 import net.minecraft.client.util.math.MatrixStack
-import net.minecraft.text.OrderedText
+import net.minecraft.text.Text
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.Direction
 import net.minecraft.util.math.MathHelper.HALF_PI
@@ -32,6 +31,9 @@ object RenderUtils {
     val MESH_BUILDER: MeshBuilder by threadLocal {
         RendererAccess.INSTANCE.renderer.requireNonNull("Renderer is null").meshBuilder()
     }
+
+    private val TEXT_RENDERER by lazy { MinecraftClient.getInstance().textRenderer }
+
     private val FLAT_QUATERNION = Quaternion.fromEulerXyz(-HALF_PI, 0f, 0f)
 
     private val ROTATION_QUATERNIONS = arrayOf(
@@ -102,7 +104,7 @@ object RenderUtils {
     }
 
     fun renderPortText(
-        text: OrderedText, side: Direction, rotation: Direction, height: Double, tr: TextRenderer, stack: MatrixStack,
+        text: Text, side: Direction, rotation: Direction, height: Double, stack: MatrixStack,
         provider: VertexConsumerProvider, light: Int
     ) {
         stack.push()
@@ -117,18 +119,17 @@ object RenderUtils {
 
         stack.scale(1f / 32f, -1f / 32f, 1f / 32f)
 
-        val width = tr.getWidth(text).toDouble()
-        stack.translate(16.0 - width / 2.0, -tr.fontHeight.toDouble(), 0.0)
+        val width = TEXT_RENDERER.getWidth(text).toDouble()
+        stack.translate(16.0 - width / 2.0, -TEXT_RENDERER.fontHeight.toDouble(), 0.0)
 
-        tr.draw(text, 0f, 0f, -1, false, stack.peek().positionMatrix, provider, true, 0, light)
+        WRTextRenderer.drawText(text, -1, true, stack.peek().positionMatrix, provider, true, 0, light)
 
         stack.pop()
     }
 
     fun renderOverlayText(
-        text: OrderedText, side: Direction, rotation: Direction, x: Double, y: Double, z: Double,
-        alignment: HorizontalAlignment, tr: TextRenderer, stack: MatrixStack, provider: VertexConsumerProvider,
-        light: Int
+        text: Text, side: Direction, rotation: Direction, x: Double, y: Double, z: Double,
+        alignment: HorizontalAlignment, stack: MatrixStack, provider: VertexConsumerProvider, light: Int
     ) {
         stack.push()
         stack.translate(0.5, 0.5, 0.5)
@@ -142,9 +143,9 @@ object RenderUtils {
 
         stack.scale(1f / 32f, -1f / 32f, 1f / 32f)
 
-        stack.translate(alignment.offset(tr.getWidth(text)), 0.0, 0.0)
+        stack.translate(alignment.offset(TEXT_RENDERER.getWidth(text)), 0.0, 0.0)
 
-        tr.draw(text, 0f, 0f, -1, false, stack.peek().positionMatrix, provider, true, 0, light)
+        WRTextRenderer.drawText(text, -1, true, stack.peek().positionMatrix, provider, true, 0, light)
 
         stack.pop()
     }

--- a/src/main/kotlin/com/kneelawk/wiredredstone/client/render/RenderUtils.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/client/render/RenderUtils.kt
@@ -32,7 +32,7 @@ object RenderUtils {
         RendererAccess.INSTANCE.renderer.requireNonNull("Renderer is null").meshBuilder()
     }
 
-    private val TEXT_RENDERER by lazy { MinecraftClient.getInstance().textRenderer }
+    private val MC = MinecraftClient.getInstance()
 
     private val FLAT_QUATERNION = Quaternion.fromEulerXyz(-HALF_PI, 0f, 0f)
 
@@ -119,8 +119,8 @@ object RenderUtils {
 
         stack.scale(1f / 32f, -1f / 32f, 1f / 32f)
 
-        val width = TEXT_RENDERER.getWidth(text).toDouble()
-        stack.translate(16.0 - width / 2.0, -TEXT_RENDERER.fontHeight.toDouble(), 0.0)
+        val width = MC.textRenderer.getWidth(text).toDouble()
+        stack.translate(16.0 - width / 2.0, -MC.textRenderer.fontHeight.toDouble(), 0.0)
 
         WRTextRenderer.drawText(text, -1, true, stack.peek().positionMatrix, provider, true, 0, light)
 
@@ -143,7 +143,7 @@ object RenderUtils {
 
         stack.scale(1f / 32f, -1f / 32f, 1f / 32f)
 
-        stack.translate(alignment.offset(TEXT_RENDERER.getWidth(text)), 0.0, 0.0)
+        stack.translate(alignment.offset(MC.textRenderer.getWidth(text)), 0.0, 0.0)
 
         WRTextRenderer.drawText(text, -1, true, stack.peek().positionMatrix, provider, true, 0, light)
 

--- a/src/main/kotlin/com/kneelawk/wiredredstone/client/render/WRTextRenderer.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/client/render/WRTextRenderer.kt
@@ -3,14 +3,25 @@ package com.kneelawk.wiredredstone.client.render
 import alexiil.mc.lib.multipart.api.AbstractPart
 import alexiil.mc.lib.multipart.api.MultipartContainer
 import alexiil.mc.lib.multipart.api.MultipartUtil
+import com.google.common.cache.CacheBuilder
+import com.google.common.cache.CacheLoader
+import com.google.common.cache.LoadingCache
+import com.kneelawk.wiredredstone.WRConstants
 import com.kneelawk.wiredredstone.client.render.part.WRPartRenderers
 import net.fabricmc.api.EnvType
 import net.fabricmc.api.Environment
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents
 import net.minecraft.client.MinecraftClient
+import net.minecraft.client.gl.SimpleFramebuffer
+import net.minecraft.client.render.RenderLayer
+import net.minecraft.client.render.Tessellator
+import net.minecraft.client.render.VertexConsumerProvider
 import net.minecraft.client.render.WorldRenderer
+import net.minecraft.text.Text
+import net.minecraft.util.Identifier
 import net.minecraft.util.hit.BlockHitResult
+import net.minecraft.util.math.Matrix4f
 import net.minecraft.util.math.Vec3d
 
 /**
@@ -18,8 +29,68 @@ import net.minecraft.util.math.Vec3d
  */
 @Environment(EnvType.CLIENT)
 object WRTextRenderer {
+    data class TextKey(val text: Text, val color: Int, val shadow: Boolean, val background: Int)
+
+    private val TEXTURE_MANAGER by lazy { MinecraftClient.getInstance().textureManager }
+    private val TEXT_RENDERER by lazy { MinecraftClient.getInstance().textRenderer }
+    private val FRAMEBUFFER_CACHE: LoadingCache<TextKey, Identifier> =
+        CacheBuilder.newBuilder().build(CacheLoader.from(::makeTexture))
+    private val TEXT_ID_MAP = mutableMapOf<TextKey, Int>()
+    private var CUR_TEXT_ID = 1
+
+    private fun makeTexture(key: TextKey): Identifier {
+        val addedSize = if (key.shadow) 1 else 0
+
+        val text = key.text.asOrderedText()
+
+        val width = TEXT_RENDERER.getWidth(text) + addedSize
+        val height = TEXT_RENDERER.fontHeight + addedSize
+        val textMat = Matrix4f()
+
+        val fb = SimpleFramebuffer(width, height, false, MinecraftClient.IS_SYSTEM_MAC)
+
+        fb.beginWrite(true)
+        fb.clear(MinecraftClient.IS_SYSTEM_MAC)
+        val immediate = VertexConsumerProvider.immediate(Tessellator.getInstance().buffer)
+        TEXT_RENDERER.draw(text, 0f, 0f, key.color, key.shadow, textMat, immediate, false, key.background, 15728880)
+        immediate.draw()
+        fb.endWrite()
+        MinecraftClient.getInstance().framebuffer.beginWrite(true)
+
+        val texture = FramebufferTexture(fb)
+        val id = textureId(key)
+        TEXTURE_MANAGER.registerTexture(id, texture)
+
+        return id
+    }
+
+    private fun textureId(key: TextKey): Identifier {
+        val id = TEXT_ID_MAP.computeIfAbsent(key) { CUR_TEXT_ID++ }
+        return WRConstants.id("text_fb/$id")
+    }
+
     fun init() {
         WorldRenderEvents.AFTER_ENTITIES.register(::render)
+    }
+
+    fun drawText(
+        text: Text, color: Int, shadow: Boolean, model: Matrix4f, provider: VertexConsumerProvider,
+        seeThrough: Boolean, background: Int, light: Int
+    ) {
+        val addedSize = if (shadow) 1 else 0
+
+        val width = (TEXT_RENDERER.getWidth(text) + addedSize).toFloat()
+        val height = (TEXT_RENDERER.fontHeight + addedSize).toFloat()
+
+        val id = FRAMEBUFFER_CACHE[TextKey(text, color, shadow, background)]
+
+        val renderLayer = if (seeThrough) RenderLayer.getTextSeeThrough(id) else RenderLayer.getText(id)
+        val consumer = provider.getBuffer(renderLayer)
+
+        consumer.vertex(model, 0f, height, 0f).color(-1).texture(0f, 1f).light(light).next()
+        consumer.vertex(model, width, height, 0f).color(-1).texture(1f, 1f).light(light).next()
+        consumer.vertex(model, width, 0f, 0f).color(-1).texture(1f, 0f).light(light).next()
+        consumer.vertex(model, 0f, 0f, 0f).color(-1).texture(0f, 0f).light(light).next()
     }
 
     private fun render(context: WorldRenderContext) {
@@ -41,7 +112,7 @@ object WRTextRenderer {
                 stack.push()
                 stack.translate(hitPos.x - cameraPos.x, hitPos.y - cameraPos.y, hitPos.z - cameraPos.z)
 
-                WRPartRenderers.bakerFor(key::class)?.renderOverlayText(key, mc.textRenderer, stack, provider, light)
+                WRPartRenderers.bakerFor(key::class)?.renderOverlayText(key, stack, provider, light)
 
                 stack.pop()
             }

--- a/src/main/kotlin/com/kneelawk/wiredredstone/client/render/part/GateDiodePartBaker.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/client/render/part/GateDiodePartBaker.kt
@@ -6,7 +6,6 @@ import com.kneelawk.wiredredstone.client.render.*
 import com.kneelawk.wiredredstone.part.key.GateDiodePartKey
 import com.kneelawk.wiredredstone.util.ConnectionUtils
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh
-import net.minecraft.client.font.TextRenderer
 import net.minecraft.client.render.VertexConsumerProvider
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.util.Identifier
@@ -68,14 +67,13 @@ object GateDiodePartBaker : AbstractPartBaker<GateDiodePartKey>() {
     }
 
     override fun renderOverlayText(
-        key: GateDiodePartKey, tr: TextRenderer, stack: MatrixStack, provider: VertexConsumerProvider, light: Int
+        key: GateDiodePartKey, stack: MatrixStack, provider: VertexConsumerProvider, light: Int
     ) {
         RenderUtils.renderPortText(
-            overlay("gate_diode.out").asOrderedText(), key.side, key.direction, 2.0 / 16.0, tr, stack, provider, light
+            overlay("gate_diode.out"), key.side, key.direction, 2.0 / 16.0, stack, provider, light
         )
         RenderUtils.renderPortText(
-            overlay("gate_diode.in").asOrderedText(), key.side, key.direction.opposite, 2.0 / 16.0, tr, stack, provider,
-            light
+            overlay("gate_diode.in"), key.side, key.direction.opposite, 2.0 / 16.0, stack, provider, light
         )
     }
 }

--- a/src/main/kotlin/com/kneelawk/wiredredstone/client/render/part/GateNotPartBaker.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/client/render/part/GateNotPartBaker.kt
@@ -10,7 +10,6 @@ import com.kneelawk.wiredredstone.client.render.WRSprites.RED_ALLOY_WIRE_UNPOWER
 import com.kneelawk.wiredredstone.part.key.GateNotPartKey
 import com.kneelawk.wiredredstone.util.ConnectionUtils
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh
-import net.minecraft.client.font.TextRenderer
 import net.minecraft.client.render.VertexConsumerProvider
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.util.Identifier
@@ -80,14 +79,13 @@ object GateNotPartBaker : AbstractPartBaker<GateNotPartKey>() {
     }
 
     override fun renderOverlayText(
-        key: GateNotPartKey, tr: TextRenderer, stack: MatrixStack, provider: VertexConsumerProvider, light: Int
+        key: GateNotPartKey, stack: MatrixStack, provider: VertexConsumerProvider, light: Int
     ) {
         RenderUtils.renderPortText(
-            overlay("gate_not.out").asOrderedText(), key.side, key.direction, 2.0 / 16.0, tr, stack, provider, light
+            overlay("gate_not.out"), key.side, key.direction, 2.0 / 16.0, stack, provider, light
         )
         RenderUtils.renderPortText(
-            overlay("gate_not.in").asOrderedText(), key.side, key.direction.opposite, 2.0 / 16.0, tr, stack, provider,
-            light
+            overlay("gate_not.in"), key.side, key.direction.opposite, 2.0 / 16.0, stack, provider, light
         )
     }
 }

--- a/src/main/kotlin/com/kneelawk/wiredredstone/client/render/part/GateRepeaterPartBaker.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/client/render/part/GateRepeaterPartBaker.kt
@@ -10,7 +10,6 @@ import com.kneelawk.wiredredstone.client.render.WRSprites.RED_ALLOY_WIRE_UNPOWER
 import com.kneelawk.wiredredstone.part.key.GateRepeaterPartKey
 import com.kneelawk.wiredredstone.util.ConnectionUtils
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh
-import net.minecraft.client.font.TextRenderer
 import net.minecraft.client.render.VertexConsumerProvider
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.util.Identifier
@@ -101,19 +100,17 @@ object GateRepeaterPartBaker : AbstractPartBaker<GateRepeaterPartKey>() {
     }
 
     override fun renderOverlayText(
-        key: GateRepeaterPartKey, tr: TextRenderer, stack: MatrixStack, provider: VertexConsumerProvider, light: Int
+        key: GateRepeaterPartKey, stack: MatrixStack, provider: VertexConsumerProvider, light: Int
     ) {
         RenderUtils.renderPortText(
-            overlay("gate_repeater.out").asOrderedText(), key.side, key.direction, 2.0 / 16.0, tr, stack, provider,
-            light
+            overlay("gate_repeater.out"), key.side, key.direction, 2.0 / 16.0, stack, provider, light
         )
         RenderUtils.renderPortText(
-            overlay("gate_repeater.in").asOrderedText(), key.side, key.direction.opposite, 2.0 / 16.0, tr, stack,
-            provider, light
+            overlay("gate_repeater.in"), key.side, key.direction.opposite, 2.0 / 16.0, stack, provider, light
         )
         RenderUtils.renderOverlayText(
-            overlay("gate_repeater.delay", (key.delay.toFloat() + 1f) / 2f).asOrderedText(), key.side, key.direction,
-            0.5, 2.0 / 16.0, 6.0 / 16.0, HorizontalAlignment.CENTER, tr, stack, provider, light
+            overlay("gate_repeater.delay", (key.delay.toFloat() + 1f) / 2f), key.side, key.direction, 0.5, 2.0 / 16.0,
+            6.0 / 16.0, HorizontalAlignment.CENTER, stack, provider, light
         )
     }
 }

--- a/src/main/kotlin/com/kneelawk/wiredredstone/client/render/part/WRPartBaker.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/client/render/part/WRPartBaker.kt
@@ -4,7 +4,6 @@ import alexiil.mc.lib.multipart.api.render.PartModelBaker
 import alexiil.mc.lib.multipart.api.render.PartModelKey
 import net.fabricmc.fabric.api.event.client.ClientSpriteRegistryCallback
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh
-import net.minecraft.client.font.TextRenderer
 import net.minecraft.client.render.VertexConsumerProvider
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.util.Identifier
@@ -13,7 +12,7 @@ import java.util.function.Consumer
 interface WRPartBaker<K : PartModelKey> : PartModelBaker<K> {
     fun getMeshForPlacementGhost(key: K): Mesh? = null
 
-    fun renderOverlayText(key: K, tr: TextRenderer, stack: MatrixStack, provider: VertexConsumerProvider, light: Int) {}
+    fun renderOverlayText(key: K, stack: MatrixStack, provider: VertexConsumerProvider, light: Int) {}
 
     fun registerModels(out: Consumer<Identifier>) {}
 

--- a/src/main/resources/wiredredstone.mixins.json
+++ b/src/main/resources/wiredredstone.mixins.json
@@ -7,6 +7,7 @@
   },
   "client": [
     "ClientRecipeBookMixin",
+    "FramebufferAccessor",
     "IdentifierMixin",
     "RenderLayerAccessor",
     "RenderPhaseAccessor"


### PR DESCRIPTION
This PR uses framebuffers for rendering gate text overlays. First gate text is rendered to a framebuffer, allowing for control over otherwise difficult parameters like shadow. Then these framebuffers are rendered in the world. Framebuffers that go unused for too long are disposed.

This means that I can both have gate overlay text be visible through blocks and have the text have shadow text without having to worry about the shadow text appearing in front of the display text. This also means that I can benefit from having fewer quads in the world.