### PR TITLE
Fix Redstone Assembler output logic

### DIFF
--- a/src/main/kotlin/com/kneelawk/wiredredstone/blockentity/RedstoneAssemblerBlockEntity.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/blockentity/RedstoneAssemblerBlockEntity.kt
@@ -328,6 +328,8 @@ class RedstoneAssemblerBlockEntity(pos: BlockPos, state: BlockState) :
     }
 
     fun canAcceptOutput(output: ItemStack): Boolean {
+        var remainingOutput = output.count
+
         for (i in OUTPUT_START_SLOT until OUTPUT_STOP_SLOT) {
             val existing = inventory[i]
             if (existing.isEmpty) {
@@ -335,14 +337,14 @@ class RedstoneAssemblerBlockEntity(pos: BlockPos, state: BlockState) :
             }
 
             if (output.isStackable && ItemStack.canCombine(existing, output)) {
-                if (existing.count + output.count <= existing.maxCount) {
+                if (existing.count + remainingOutput <= existing.maxCount) {
                     return true
                 } else if (existing.count < existing.maxCount) {
-                    output.decrement(existing.maxCount - existing.count)
+                    remainingOutput -= existing.maxCount - existing.count
                 }
             }
 
-            if (output.isEmpty) {
+            if (remainingOutput == 0) {
                 return true
             }
         }


### PR DESCRIPTION
The `canAcceptOutput` function was mutating the count of the passed ItemStack, causing the Redstone Assembler to sometimes output too few items depending on what was already in the output slots.

This issue can be reproduced simply by setting the Redstone to crafting mode and putting a bunch of iron ingots into the crafting grid. After a stack of iron nuggets has accumulated in the output slots, fewer than 9 nuggets will be produced for each subsequent ingot.