### PR TITLE
0.4.x-1.19 Create Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,8 @@ Many Wired Redstone gates and wires will show extra information in the WTHIT HUD
 
 ## Known Issues
 
-* LibMultiPart blocks (meaning all wires, gates, etc.) will crash when moved by Create
-  contraptions (**[#15](https://github.com/Kneelawk/WiredRedstone/issues/15)**). I am working on finding a solution to
-  this, but I am not sure when it will be ready.
+* ~~LibMultiPart blocks (meaning all wires, gates, etc.) will crash when moved by Create
+  contraptions (**[#15](https://github.com/Kneelawk/WiredRedstone/issues/15)**).~~ Fixed in `v0.4.11+1.19.2`.
 * Under certain circumstances Not Enough Crashes can get Wired Redstone's rendering system into an invalid state while
   generating a crash report, causing an actual crash (**[#12](https://github.com/Kneelawk/WiredRedstone/issues/12)**).
 * Server crashes can cause wires to stop working correctly and appear disconnected or refuse to connect when placed in

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,8 +56,27 @@ repositories {
         name = "JitPack"
         content {
             includeGroup("com.github.LlamaLad7")
+
+            // Create stuff
+            includeGroup("com.github.AlphaMode")
+            includeGroup("com.github.Chocohead")
+            includeGroup("com.github.Draylar.omega-config")
         }
     }
+
+    // Create Stuff
+    maven("https://mvn.devos.one/snapshots/") { name = "Create" }
+    maven("https://ladysnake.jfrog.io/artifactory/mods") { name = "Ladysnake" }
+    maven("https://maven.tterrag.com/") { name = "Flywheel" }
+    maven("https://maven.cafeteria.dev/releases/") { name = "Cafeteria" } // for Fake Player API
+    maven("https://maven.jamieswhiteshirt.com/libs-release") // for Reach Entity Attributes
+    maven("https://cursemaven.com") { // for Forge Config API Port
+        name = "Cursemaven"
+        content {
+            includeGroup("curse.maven")
+        }
+    }
+
 //    mavenLocal()
 }
 
@@ -92,6 +111,11 @@ dependencies {
     modImplementation("com.kneelawk:graphlib:$graphlibVersion")
     include("com.kneelawk:graphlib:$graphlibVersion")
 
+    // LMP Compat
+    val lmpCompatVersion: String by project
+    modImplementation("com.kneelawk:lmp-compat:$lmpCompatVersion")
+    include("com.kneelawk:lmp-compat:$lmpCompatVersion")
+
     // TechReborn Lightweight Energy API
     val energyVersion: String by project
     modApi("teamreborn:energy:$energyVersion") {
@@ -117,6 +141,13 @@ dependencies {
     val emiVersion: String by project
     modCompileOnly("dev.emi:emi:$emiVersion") {
         isTransitive = false
+    }
+
+    // Create
+    val createVersion: String by project
+    val createMinecraftVersion: String by project
+    modCompileOnly("com.simibubi.create:create-fabric-$createMinecraftVersion:$createVersion") {
+        exclude("net.fabricmc.fabric-api")
     }
 
     //
@@ -161,6 +192,11 @@ dependencies {
     // EMI
     modRuntimeOnly("dev.emi:emi:$emiVersion") {
         isTransitive = false
+    }
+
+    // Create
+    modRuntimeOnly("com.simibubi.create:create-fabric-$createMinecraftVersion:$createVersion") {
+        exclude("net.fabricmc.fabric-api")
     }
 
     // Quiltflower

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -167,22 +167,6 @@ dependencies {
 
     // CC: Restitched
     modRuntimeOnly("maven.modrinth:cc-restitched:$ccRestitchedVersion")
-    val clothConfigVersion: String by project
-    modRuntimeOnly("me.shedaniel.cloth:cloth-config-fabric:$clothConfigVersion") {
-        exclude("net.fabricmc.fabric-api")
-    }
-    val clothApiVersion: String by project
-    modRuntimeOnly("me.shedaniel.cloth.api:cloth-utils-v1:$clothApiVersion") {
-        exclude("net.fabricmc.fabric-api")
-    }
-    val cobaltVersion: String by project
-    modRuntimeOnly("org.squiddev:Cobalt:$cobaltVersion") {
-        exclude("net.fabricmc.fabric-api")
-    }
-    val nettyVersion: String by project
-    runtimeOnly("io.netty:netty-codec-http:$nettyVersion")
-    val nightConfigVersion: String by project
-    runtimeOnly("com.electronwill.night-config:toml:$nightConfigVersion")
 
     // REI
 //    modRuntimeOnly("me.shedaniel:RoughlyEnoughItems-fabric:$reiVersion") {

--- a/changelogs/changelog-v0.4.11+1.19.2.md
+++ b/changelogs/changelog-v0.4.11+1.19.2.md
@@ -1,0 +1,5 @@
+# Wired Redstone v0.4.11+1.19.2
+
+Wired Redstone version 0.4.11 for Minecraft 1.19.2
+
+Changes:

--- a/changelogs/changelog-v0.4.11+1.19.2.md
+++ b/changelogs/changelog-v0.4.11+1.19.2.md
@@ -3,3 +3,8 @@
 Wired Redstone version 0.4.11 for Minecraft 1.19.2
 
 Changes:
+
+* Updates development environment to build against 1.19.2.
+* Fixes crashes when Wired Redstone components are moved by Create
+  contraptions ([#15](https://github.com/Kneelawk/WiredRedstone/issues/15)).
+* Allows Create contraptions to properly move and rotate Wired Redstone components.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style = official
-org.gradle.jvmargs = -Xmx1G
+org.gradle.jvmargs = -Xmx2G
 org.gradle.warning.mode = all
 
 # Check these on https://fabricmc.net/develop/
@@ -35,21 +35,14 @@ fabricKotlinVersion = 1.8.1+kotlin.1.7.0
 ccRestitchedVersion = 1.101.2+1.19.1
 createVersion = 0.5.0g-800+1.19.2
 createMinecraftVersion = 1.19.2
-emiVersion = 0.4.0+1.19
+emiVersion = 0.5.0+1.19.2
 energyVersion = 2.2.0
 graphlibVersion = 0.3.3+1.19
 lmpVersion = 0.8.0-pre.1.6+kneelawk
 lmpCompatVersion = 0.2.1+1.19
 mixinExtrasVersion = 0.0.11
-reiVersion = 9.1.500
-wthitVersion = 5.4.3
-
-# CC: Restitched Dependencies
-clothApiVersion = 4.0.65
-clothConfigVersion = 7.0.72
-cobaltVersion = 0.5.6
-nettyVersion = 4.1.77.Final
-nightConfigVersion = 3.6.5
+reiVersion = 9.1.577
+wthitVersion = 5.13.4
 
 # Modrinth Dependencies
 fabricApiMrProjectId = P7dR8mSH

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,13 +3,13 @@ org.gradle.jvmargs = -Xmx1G
 org.gradle.warning.mode = all
 
 # Check these on https://fabricmc.net/develop/
-minecraftVersion = 1.19
-yarnMappings = 1.19+build.4
-loaderVersion = 0.14.6
+minecraftVersion = 1.19.2
+yarnMappings = 1.19.2+build.28
+loaderVersion = 0.14.11
 
 #Fabric api
-fabricVersion = 0.57.0+1.19
-loomVersion = 0.12-SNAPSHOT
+fabricVersion = 0.68.0+1.19.2
+loomVersion = 1.0-SNAPSHOT
 loomQuiltflowerVersion = 1.7.3
 
 # Plugin Sersions
@@ -17,26 +17,29 @@ minotaurVersion = 2.+
 curseGradleVersion = 1.4.0
 
 # Mod Properties
-modVersion = 0.4.99+1.19.local
+modVersion = 0.4.99+1.19.2.local
 mavenGroup = com.kneelawk
 archivesBaseName = wired-redstone
 mrProjectId = lyYGrdho
 mrVersionType = beta
-mrGameVersions = 1.19,1.19.1,1.19.2
+mrGameVersions = 1.19.2
 mrLoaders = fabric, quilt
 cfReleaseType = beta
-cfMinecraftVersions = 1.19,1.19.1,1.19.2
+cfMinecraftVersions = 1.19.2
 
 # Kotlin
 systemProp.kotlinVersion = 1.7.0
 fabricKotlinVersion = 1.8.1+kotlin.1.7.0
 
 # Mod Dependencies
-ccRestitchedVersion = 1.101.0+1.19
+ccRestitchedVersion = 1.101.2+1.19.1
+createVersion = 0.5.0g-800+1.19.2
+createMinecraftVersion = 1.19.2
 emiVersion = 0.4.0+1.19
 energyVersion = 2.2.0
 graphlibVersion = 0.3.3+1.19
-lmpVersion = 0.8.0-pre.1.5+kneelawk
+lmpVersion = 0.8.0-pre.1.6+kneelawk
+lmpCompatVersion = 0.2.1+1.19
 mixinExtrasVersion = 0.0.11
 reiVersion = 9.1.500
 wthitVersion = 5.4.3

--- a/src/main/kotlin/com/kneelawk/wiredredstone/WiredRedstoneMod.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/WiredRedstoneMod.kt
@@ -3,6 +3,7 @@ package com.kneelawk.wiredredstone
 import com.kneelawk.wiredredstone.block.WRBlocks
 import com.kneelawk.wiredredstone.blockentity.WRBlockEntities
 import com.kneelawk.wiredredstone.compat.cc.CCIntegrationHandler
+import com.kneelawk.wiredredstone.compat.create.CreateCompatHandler
 import com.kneelawk.wiredredstone.compat.emi.EMIIntegrationHandler
 import com.kneelawk.wiredredstone.item.WRItems
 import com.kneelawk.wiredredstone.logic.RedstoneLogic
@@ -11,6 +12,7 @@ import com.kneelawk.wiredredstone.net.WRNetworking
 import com.kneelawk.wiredredstone.node.WRBlockNodeDiscoverer
 import com.kneelawk.wiredredstone.node.WRBlockNodes
 import com.kneelawk.wiredredstone.part.WRParts
+import com.kneelawk.wiredredstone.part.event.WRChunkUnloadEvent
 import com.kneelawk.wiredredstone.recipe.WRRecipes
 import com.kneelawk.wiredredstone.screenhandler.WRScreenHandlers
 
@@ -25,9 +27,11 @@ fun init() {
     WRRecipes.init()
     WRScreenHandlers.init()
     WRNetworking.init()
+    WRChunkUnloadEvent.init()
 
     CCIntegrationHandler.init()
     EMIIntegrationHandler.init()
+    CreateCompatHandler.init()
 
     RedstoneLogic.init()
     PhantomRedstone.init()

--- a/src/main/kotlin/com/kneelawk/wiredredstone/compat/create/CreateCompat.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/compat/create/CreateCompat.kt
@@ -1,0 +1,5 @@
+package com.kneelawk.wiredredstone.compat.create
+
+interface CreateCompat {
+    fun init()
+}

--- a/src/main/kotlin/com/kneelawk/wiredredstone/compat/create/CreateCompatHandler.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/compat/create/CreateCompatHandler.kt
@@ -1,0 +1,15 @@
+package com.kneelawk.wiredredstone.compat.create
+
+import com.kneelawk.wiredredstone.util.ReflectionUtils
+import net.fabricmc.loader.api.FabricLoader
+
+object CreateCompatHandler {
+    private var compat: CreateCompat? = null
+
+    fun init() {
+        if (FabricLoader.getInstance().isModLoaded("create")) {
+            compat = ReflectionUtils.loadObject("com.kneelawk.wiredredstone.compat.create.CreateCompatImpl")
+            compat?.init()
+        }
+    }
+}

--- a/src/main/kotlin/com/kneelawk/wiredredstone/compat/create/CreateCompatImpl.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/compat/create/CreateCompatImpl.kt
@@ -1,0 +1,20 @@
+package com.kneelawk.wiredredstone.compat.create
+
+import alexiil.mc.lib.multipart.api.MultipartUtil
+import com.kneelawk.wiredredstone.WRLog
+import com.kneelawk.wiredredstone.part.event.WRPartPreMoveEvent
+import com.simibubi.create.content.contraptions.components.structureMovement.BlockMovementChecks
+
+@Suppress("unused")
+object CreateCompatImpl : CreateCompat {
+    override fun init() {
+        WRLog.log.info("Wired Redstone: enabling Create compatibility!")
+
+        BlockMovementChecks.registerMovementNecessaryCheck { _, world, pos ->
+            val event = WRPartPreMoveEvent()
+            MultipartUtil.get(world, pos)?.fireEvent(event)
+
+            if (event.movementNecessary) BlockMovementChecks.CheckResult.SUCCESS else BlockMovementChecks.CheckResult.PASS
+        }
+    }
+}

--- a/src/main/kotlin/com/kneelawk/wiredredstone/part/AbstractRotatedPart.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/part/AbstractRotatedPart.kt
@@ -1,11 +1,15 @@
 package com.kneelawk.wiredredstone.part
 
+import alexiil.mc.lib.multipart.api.MultipartEventBus
 import alexiil.mc.lib.multipart.api.MultipartHolder
 import alexiil.mc.lib.multipart.api.PartDefinition
+import alexiil.mc.lib.multipart.api.event.PartPreTransformEvent
+import alexiil.mc.lib.multipart.api.event.PartTransformEvent
 import alexiil.mc.lib.net.IMsgReadCtx
 import alexiil.mc.lib.net.IMsgWriteCtx
 import alexiil.mc.lib.net.NetByteBuf
 import com.kneelawk.wiredredstone.util.DirectionUtils
+import com.kneelawk.wiredredstone.util.RotationUtils
 import com.kneelawk.wiredredstone.util.SidedOrientation
 import net.minecraft.nbt.NbtCompound
 import net.minecraft.util.math.Direction
@@ -16,6 +20,8 @@ abstract class AbstractRotatedPart : AbstractConnectablePart, RotatedPart {
 
     val orientation: SidedOrientation
         get() = SidedOrientation(side, direction)
+
+    private var oldSide = side
 
     constructor(
         definition: PartDefinition, holder: MultipartHolder, side: Direction, connections: UByte, direction: Direction
@@ -55,5 +61,32 @@ abstract class AbstractRotatedPart : AbstractConnectablePart, RotatedPart {
     override fun readRenderData(buffer: NetByteBuf, ctx: IMsgReadCtx) {
         super.readRenderData(buffer, ctx)
         direction = DirectionUtils.HORIZONTALS[buffer.readFixedBits(2).coerceIn(0..3)]
+    }
+
+    override fun onAdded(bus: MultipartEventBus) {
+        super.onAdded(bus)
+
+        bus.addContextlessListener(this, PartPreTransformEvent::class.java) {
+            oldSide = side
+        }
+
+        bus.addListener(this, PartTransformEvent::class.java) { e ->
+            val oldDirection = direction
+            val old = RotationUtils.rotatedDirection(oldSide, oldDirection)
+            val newSide = e.transformation.map(oldSide)
+            val new = e.transformation.map(old)
+            direction = RotationUtils.unrotatedDirection(newSide, new)
+
+            assert(DirectionUtils.isHorizontal(direction)) {
+                "Ended up with non-planar direction after rotation!\n" +
+                        "Transformation: ${e.transformation}\n" +
+                        "Old Direction : $oldDirection\n" +
+                        "Old Un-Rotated: $old\n" +
+                        "Old Side      : $oldSide\n" +
+                        "New Side      : $newSide\n" +
+                        "New Un-Rotated: $new\n" +
+                        "New Direction : $direction"
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/kneelawk/wiredredstone/part/AbstractSidedPart.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/part/AbstractSidedPart.kt
@@ -1,13 +1,13 @@
 package com.kneelawk.wiredredstone.part
 
 import alexiil.mc.lib.multipart.api.*
-import alexiil.mc.lib.multipart.api.event.NeighbourUpdateEvent
-import alexiil.mc.lib.multipart.api.event.PartAddedEvent
-import alexiil.mc.lib.multipart.api.event.PartRemovedEvent
+import alexiil.mc.lib.multipart.api.event.*
 import alexiil.mc.lib.net.IMsgReadCtx
 import alexiil.mc.lib.net.IMsgWriteCtx
 import alexiil.mc.lib.net.NetByteBuf
 import com.kneelawk.graphlib.GraphLib
+import com.kneelawk.wiredredstone.part.event.WRChunkUnloadEvent
+import com.kneelawk.wiredredstone.part.event.WRPartPreMoveEvent
 import com.kneelawk.wiredredstone.util.PlacementUtils
 import com.kneelawk.wiredredstone.util.SimpleItemDropTarget
 import com.kneelawk.wiredredstone.util.connectable.ConnectableUtils
@@ -33,16 +33,24 @@ import net.minecraft.util.shape.VoxelShape
  *
  * Subtypes of this could be parts for wires, bundle cables, or gates.
  */
-abstract class AbstractSidedPart(definition: PartDefinition, holder: MultipartHolder, override val side: Direction) :
+abstract class AbstractSidedPart(definition: PartDefinition, holder: MultipartHolder, side: Direction) :
     AbstractPart(definition, holder), BlockNodeContainer, SidedPart {
 
+    final override var side: Direction = side
+        private set
     private var ctx: SidedPartContext? = null
 
     private val shapeCache = mutableMapOf<BlockPos, VoxelShape>()
 
+    private var noBreak = false
+    private var unloading = false
+
     constructor(definition: PartDefinition, holder: MultipartHolder, tag: NbtCompound) : this(
         definition, holder, Direction.byId(tag.getByte("side").toInt())
-    )
+    ) {
+        // defaults to false
+        noBreak = tag.getBoolean("noBreak")
+    }
 
     constructor(definition: PartDefinition, holder: MultipartHolder, buffer: NetByteBuf, ctx: IMsgReadCtx) : this(
         definition, holder, Direction.byId(buffer.readFixedBits(3))
@@ -51,6 +59,11 @@ abstract class AbstractSidedPart(definition: PartDefinition, holder: MultipartHo
     override fun toTag(): NbtCompound {
         val tag = super.toTag()
         tag.putByte("side", side.id.toByte())
+
+        if (noBreak) {
+            tag.putBoolean("noBreak", true)
+        }
+
         return tag
     }
 
@@ -59,18 +72,47 @@ abstract class AbstractSidedPart(definition: PartDefinition, holder: MultipartHo
         buffer.writeFixedBits(side.id, 3)
     }
 
+    override fun writeRenderData(buffer: NetByteBuf, ctx: IMsgWriteCtx) {
+        super.writeRenderData(buffer, ctx)
+        buffer.writeFixedBits(side.id, 3)
+    }
+
+    override fun readRenderData(buffer: NetByteBuf, ctx: IMsgReadCtx) {
+        super.readRenderData(buffer, ctx)
+        // No SideContext on the client-side
+        side = Direction.byId(buffer.readFixedBits(3))
+    }
+
     override fun getSidedContext(): SidedPartContext {
         return ctx.requireNonNull("SidedPartContext is still null (onAdded must not have been called yet)")
     }
 
     override fun onAdded(bus: MultipartEventBus) {
-        ctx = holder.container.getFirstPart(AbstractSidedPart::class.java)?.ctx ?: SidedPartContext(bus)
+        // nothing here needs to be done on the client
+        if (getWorld().isClient) return
+
+        ctx = holder.container.getFirstPart(AbstractSidedPart::class.java) { it.ctx != null }?.ctx
+            ?: SidedPartContext(bus)
         ctx!!.setPart(side, this)
 
+        // Detects when a block supporting this one is broken
+
+        bus.addRunOnceListener(this, PartTickEvent::class.java) {
+            if (!getWorld().isClient) {
+                noBreak = false
+            }
+        }
+
+        bus.addListener(this, WRPartPreMoveEvent::class.java) {
+            it.setMovementNecessary()
+            noBreak = true
+        }
+
+        // also handles some connection blockage detection
         bus.addListener(this, NeighbourUpdateEvent::class.java) {
             val world = getWorld()
             if (world is ServerWorld) {
-                if (shouldBreak()) {
+                if (!noBreak && shouldBreak()) {
                     removeAndDrop()
                 } else {
                     // updating connections is expensive, so we want to make sure we *really* need to do it first
@@ -84,6 +126,8 @@ abstract class AbstractSidedPart(definition: PartDefinition, holder: MultipartHo
                 }
             }
         }
+
+        // Connection Blockage Detection
 
         bus.addListener(this, PartAddedEvent::class.java) {
             val world = getWorld()
@@ -100,6 +144,45 @@ abstract class AbstractSidedPart(definition: PartDefinition, holder: MultipartHo
                 GraphLib.getController(world).updateConnections(getSidedPos())
             }
         }
+
+        // Removal Detection
+
+        bus.addContextlessListener(this, WRChunkUnloadEvent::class.java) {
+            unloading = true
+        }
+
+        bus.addContextlessListener(this, PartContainerState.Invalidate::class.java) {
+            if (!unloading) {
+                onRemoved()
+            }
+        }
+
+        // Rotation Handling
+
+        bus.addContextlessListener(this, PartPreTransformEvent::class.java) {
+            // Remove self from the sided context until after the transformation so different parts don't trample each
+            // other
+            ctx.requireNonNull("Attempted rotation but ctx is null!")
+                .setPart(side, null)
+        }
+
+        bus.addListener(this, PartTransformEvent::class.java) { e ->
+            side = e.transformation.map(side)
+        }
+
+        bus.addContextlessListener(this, PartPostTransformEvent::class.java) {
+            // Now re-add self since all the transformations are done
+            ctx.requireNonNull("Attempted rotation but ctx is null!")
+                .setPart(side, this)
+
+            // Update the nodes here
+            val world = getWorld()
+            if (world is ServerWorld) {
+                GraphLib.getController(world).updateNodes(getPos())
+            }
+        }
+
+        // Connection Fixing On Load
 
         val world = getWorld()
         if (!world.isClient && world is ServerWorld) {
@@ -144,7 +227,11 @@ abstract class AbstractSidedPart(definition: PartDefinition, holder: MultipartHo
     }
 
     override fun onRemoved() {
-        ctx!!.setPart(side, null)
+        // Nothing here needs to be done on the client
+        if (getWorld().isClient) return
+
+        ctx.requireNonNull("Tried to remove a part before it was added! (SidedPartContext is still null)")
+            .setPart(side, null)
 
         val world = getWorld()
         if (!world.isClient && world is ServerWorld) {

--- a/src/main/kotlin/com/kneelawk/wiredredstone/part/SidedPart.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/part/SidedPart.kt
@@ -2,12 +2,22 @@ package com.kneelawk.wiredredstone.part
 
 import alexiil.mc.lib.multipart.api.MultipartUtil
 import com.kneelawk.graphlib.util.SidedPos
+import com.kneelawk.wiredredstone.WRLog
 import net.minecraft.util.math.Direction
 import net.minecraft.world.BlockView
+import net.minecraft.world.World
 
 interface SidedPart : WRPart {
     companion object {
         fun getPart(world: BlockView, pos: SidedPos): SidedPart? {
+            if (world is World && world.isClient) {
+                WRLog.log.warn(
+                    "Something attempted to get a sided part on the client. This is not reliable and should not be attempted.",
+                    RuntimeException("Stack Trace")
+                )
+                return null
+            }
+
             val container = MultipartUtil.get(world, pos.pos) ?: return null
             return container.getFirstPart(SidedPart::class.java)?.getSidedContext()?.getPart(pos.side)
         }

--- a/src/main/kotlin/com/kneelawk/wiredredstone/part/event/WRChunkUnloadEvent.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/part/event/WRChunkUnloadEvent.kt
@@ -1,0 +1,22 @@
+package com.kneelawk.wiredredstone.part.event
+
+import alexiil.mc.lib.multipart.api.event.ContextlessEvent
+import alexiil.mc.lib.multipart.api.event.MultipartEvent
+import alexiil.mc.lib.multipart.impl.MultipartBlockEntity
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents
+
+/**
+ * Fired on the server when a part's chunk is unloaded for any reason.
+ */
+object WRChunkUnloadEvent : MultipartEvent(), ContextlessEvent {
+    fun init() {
+        ServerChunkEvents.CHUNK_UNLOAD.register { _, chunk ->
+            for ((_, be) in chunk.blockEntities) {
+                // FIXME: using LMP internal classes
+                if (be is MultipartBlockEntity) {
+                    be.container.eventBus.fireEvent(WRChunkUnloadEvent)
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/kneelawk/wiredredstone/part/event/WRPartPreMoveEvent.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/part/event/WRPartPreMoveEvent.kt
@@ -1,0 +1,15 @@
+package com.kneelawk.wiredredstone.part.event
+
+import alexiil.mc.lib.multipart.api.event.MultipartEvent
+
+/**
+ * Currently fired before Create attempts to move a multipart.
+ */
+class WRPartPreMoveEvent : MultipartEvent() {
+    var movementNecessary: Boolean = false
+        private set
+
+    fun setMovementNecessary() {
+        movementNecessary = true
+    }
+}

--- a/src/main/kotlin/com/kneelawk/wiredredstone/recipe/RedstoneAssemblerShapedRecipe.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/recipe/RedstoneAssemblerShapedRecipe.kt
@@ -249,7 +249,7 @@ class RedstoneAssemblerShapedRecipe(
         val defaultedList = this.ingredients
         return (defaultedList.isEmpty() || defaultedList.stream()
             .filter { ingredient: Ingredient -> !ingredient.isEmpty }
-            .anyMatch { ingredient: Ingredient -> ingredient.matchingStacks.isNullOrEmpty() })
+            .anyMatch { ingredient: Ingredient -> ingredient.getMatchingStacks().isEmpty() })
     }
 
     override fun getId(): Identifier = id

--- a/src/main/kotlin/com/kneelawk/wiredredstone/recipe/RedstoneAssemblerShapedRecipe.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/recipe/RedstoneAssemblerShapedRecipe.kt
@@ -249,7 +249,7 @@ class RedstoneAssemblerShapedRecipe(
         val defaultedList = this.ingredients
         return (defaultedList.isEmpty() || defaultedList.stream()
             .filter { ingredient: Ingredient -> !ingredient.isEmpty }
-            .anyMatch { ingredient: Ingredient -> ingredient.matchingStacks.isEmpty() })
+            .anyMatch { ingredient: Ingredient -> ingredient.matchingStacks.isNullOrEmpty() })
     }
 
     override fun getId(): Identifier = id


### PR DESCRIPTION
# This PR
This PR allows Wired Redstone components (or any LMP parts) to be moved by Create contraptions without crashing the game.

Much of the code for this compatibility was added to LMP directly. However any Create-specific LMP code is actually inside an LMP addon called LMP Compat that will be included in Wired Redstone distributions.

Some Create-specific code has also been added to Wired Redstone to prevent components from falling off of create contraptions when the contraptions are being placed back in the world.

# Testing
This PR has tested with moving and rotating Create contraptions.

# Associated Issues
This fixes #15.