### PR TITLE
Wire / Cable State Scrolling Feature

### DIFF
--- a/src/main/java/com/kneelawk/wiredredstone/mixin/api/MouseScrollListener.java
+++ b/src/main/java/com/kneelawk/wiredredstone/mixin/api/MouseScrollListener.java
@@ -1,0 +1,5 @@
+package com.kneelawk.wiredredstone.mixin.api;
+
+public interface MouseScrollListener {
+    void onMouseScroll(long window, double scrollDeltaX, double scrollDeltaY);
+}

--- a/src/main/java/com/kneelawk/wiredredstone/mixin/api/MouseScrollListenerRegistry.java
+++ b/src/main/java/com/kneelawk/wiredredstone/mixin/api/MouseScrollListenerRegistry.java
@@ -1,0 +1,18 @@
+package com.kneelawk.wiredredstone.mixin.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MouseScrollListenerRegistry {
+    private static final List<MouseScrollListener> listeners = new ArrayList<>();
+
+    public static void registerListener(MouseScrollListener listener) {
+        listeners.add(listener);
+    }
+
+    public static void notifyListeners(long window, double scrollDeltaX, double scrollDeltaY) {
+        for (MouseScrollListener listener : listeners) {
+            listener.onMouseScroll(window, scrollDeltaX, scrollDeltaY);
+        }
+    }
+}

--- a/src/main/java/com/kneelawk/wiredredstone/mixin/impl/InGameHudMixin.java
+++ b/src/main/java/com/kneelawk/wiredredstone/mixin/impl/InGameHudMixin.java
@@ -1,64 +1,15 @@
 package com.kneelawk.wiredredstone.mixin.impl;
 
 import com.kneelawk.wiredredstone.keybinding.WRKeyBindings;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.hud.InGameHud;
-import net.minecraft.item.ItemStack;
-import net.minecraft.text.MutableText;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Objects;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin {
-    @Shadow private int heldItemTooltipFade;
-    @Shadow private ItemStack currentStack;
-    @Final @Shadow private MinecraftClient client;
-    @Shadow public abstract TextRenderer getTextRenderer();
-    @Shadow private int scaledWidth;
-    @Shadow private int scaledHeight;
-
-    @Inject(at = @At("HEAD"), method = "renderHeldItemTooltip", cancellable = true)
-    private void renderHeldItemTooltip(GuiGraphics graphics, CallbackInfo ci) {
-        this.client.getProfiler().push("selectedItemName");
-        if (this.heldItemTooltipFade > 0 && !this.currentStack.isEmpty()) {
-            MutableText mutableText = Text.empty().append(this.currentStack.getName()).formatted(this.currentStack.getRarity().formatting);
-            if (this.currentStack.hasCustomName()) {
-                mutableText.formatted(Formatting.ITALIC);
-            }
-            int i = this.getTextRenderer().getWidth(mutableText);
-            int j = (this.scaledWidth - i) / 2;
-            int k = this.scaledHeight - 59;
-            assert this.client.interactionManager != null;
-            if (!this.client.interactionManager.hasStatusBars()) {
-                k += 14;
-            }
-
-            int l = (int)((float)this.heldItemTooltipFade * 256.0F / 10.0F);
-            if (l > 255) {
-                l = 255;
-            }
-
-            if (l > 0) {
-                int var10001 = j - 2;
-                int var10002 = k - 2;
-                int var10003 = j + i + 2;
-                Objects.requireNonNull(this.getTextRenderer());
-                graphics.fill(var10001, var10002, var10003, k + 9 + 2, this.client.options.getTextBackgroundColor(0));
-                graphics.drawShadowedText(this.getTextRenderer(), mutableText, j, k - WRKeyBindings.getHeldItemTooltipOffset(), 16777215 + (l << 24));
-            }
-        }
-
-        this.client.getProfiler().pop();
-        ci.cancel();
+    @ModifyArg(method = "renderHeldItemTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;drawShadowedText(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/text/Text;III)I"), index = 3)
+    private int modifyHeldItemTooltipOffset(int offset) {
+        return offset - WRKeyBindings.getHeldItemTooltipOffset();
     }
 }

--- a/src/main/java/com/kneelawk/wiredredstone/mixin/impl/InGameHudMixin.java
+++ b/src/main/java/com/kneelawk/wiredredstone/mixin/impl/InGameHudMixin.java
@@ -1,0 +1,64 @@
+package com.kneelawk.wiredredstone.mixin.impl;
+
+import com.kneelawk.wiredredstone.keybinding.WRKeyBindings;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Objects;
+
+@Mixin(InGameHud.class)
+public abstract class InGameHudMixin {
+    @Shadow private int heldItemTooltipFade;
+    @Shadow private ItemStack currentStack;
+    @Final @Shadow private MinecraftClient client;
+    @Shadow public abstract TextRenderer getTextRenderer();
+    @Shadow private int scaledWidth;
+    @Shadow private int scaledHeight;
+
+    @Inject(at = @At("HEAD"), method = "renderHeldItemTooltip", cancellable = true)
+    private void renderHeldItemTooltip(GuiGraphics graphics, CallbackInfo ci) {
+        this.client.getProfiler().push("selectedItemName");
+        if (this.heldItemTooltipFade > 0 && !this.currentStack.isEmpty()) {
+            MutableText mutableText = Text.empty().append(this.currentStack.getName()).formatted(this.currentStack.getRarity().formatting);
+            if (this.currentStack.hasCustomName()) {
+                mutableText.formatted(Formatting.ITALIC);
+            }
+            int i = this.getTextRenderer().getWidth(mutableText);
+            int j = (this.scaledWidth - i) / 2;
+            int k = this.scaledHeight - 59;
+            assert this.client.interactionManager != null;
+            if (!this.client.interactionManager.hasStatusBars()) {
+                k += 14;
+            }
+
+            int l = (int)((float)this.heldItemTooltipFade * 256.0F / 10.0F);
+            if (l > 255) {
+                l = 255;
+            }
+
+            if (l > 0) {
+                int var10001 = j - 2;
+                int var10002 = k - 2;
+                int var10003 = j + i + 2;
+                Objects.requireNonNull(this.getTextRenderer());
+                graphics.fill(var10001, var10002, var10003, k + 9 + 2, this.client.options.getTextBackgroundColor(0));
+                graphics.drawShadowedText(this.getTextRenderer(), mutableText, j, k - WRKeyBindings.getHeldItemTooltipOffset(), 16777215 + (l << 24));
+            }
+        }
+
+        this.client.getProfiler().pop();
+        ci.cancel();
+    }
+}

--- a/src/main/java/com/kneelawk/wiredredstone/mixin/impl/MouseMixin.java
+++ b/src/main/java/com/kneelawk/wiredredstone/mixin/impl/MouseMixin.java
@@ -1,0 +1,16 @@
+package com.kneelawk.wiredredstone.mixin.impl;
+
+import com.kneelawk.wiredredstone.mixin.api.MouseScrollListenerRegistry;
+import net.minecraft.client.Mouse;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Mouse.class)
+public class MouseMixin {
+    @Inject(at = @At("HEAD"), method = "onMouseScroll")
+    private void onMouseScroll(long window, double scrollDeltaX, double scrollDeltaY, CallbackInfo ci) {
+        MouseScrollListenerRegistry.notifyListeners(window, scrollDeltaX, scrollDeltaY);
+    }
+}

--- a/src/main/java/com/kneelawk/wiredredstone/mixin/impl/PlayerInventoryMixin.java
+++ b/src/main/java/com/kneelawk/wiredredstone/mixin/impl/PlayerInventoryMixin.java
@@ -1,0 +1,18 @@
+package com.kneelawk.wiredredstone.mixin.impl;
+
+import com.kneelawk.wiredredstone.keybinding.WRKeyBindings;
+import net.minecraft.entity.player.PlayerInventory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PlayerInventory.class)
+public abstract class PlayerInventoryMixin {
+    @Inject(at = @At("HEAD"), method = "scrollInHotbar(D)V", cancellable = true)
+    private void disableScrolling(double scrollAmount, CallbackInfo callbackInfo) {
+        if (!WRKeyBindings.isHotbarScrollEnabled()) {
+            callbackInfo.cancel();
+        }
+    }
+}

--- a/src/main/kotlin/com/kneelawk/wiredredstone/WiredRedstoneMod.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/WiredRedstoneMod.kt
@@ -15,6 +15,7 @@ import com.kneelawk.wiredredstone.node.WRBlockNodes
 import com.kneelawk.wiredredstone.part.WRParts
 import com.kneelawk.wiredredstone.recipe.WRRecipes
 import com.kneelawk.wiredredstone.screenhandler.WRScreenHandlers
+import com.kneelawk.wiredredstone.keybinding.WRKeyBindings
 
 @Suppress("unused")
 fun init() {
@@ -29,6 +30,7 @@ fun init() {
     WRRecipes.init()
     WRScreenHandlers.init()
     WRNetworking.init()
+    WRKeyBindings.init()
 
     CCIntegrationHandler.init()
     EMIIntegrationHandler.init()

--- a/src/main/kotlin/com/kneelawk/wiredredstone/keybinding/WRKeyBindings.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/keybinding/WRKeyBindings.kt
@@ -1,0 +1,123 @@
+package com.kneelawk.wiredredstone.keybinding
+
+import com.kneelawk.wiredredstone.item.WRItems.BUNDLED_CABLES
+import com.kneelawk.wiredredstone.item.WRItems.INSULATED_WIRES
+import com.kneelawk.wiredredstone.item.WRItems.RED_ALLOY_WIRE
+import com.kneelawk.wiredredstone.item.WRItems.STANDING_BUNDLED_CABLES
+import com.kneelawk.wiredredstone.item.WRItems.STANDING_INSULATED_WIRES
+import com.kneelawk.wiredredstone.item.WRItems.STANDING_RED_ALLOY_WIRE
+import com.kneelawk.wiredredstone.mixin.api.MouseScrollListenerRegistry
+import com.kneelawk.wiredredstone.net.WRNetworking
+import com.mojang.blaze3d.platform.InputUtil
+import io.netty.buffer.Unpooled
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking
+import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback
+import net.minecraft.client.MinecraftClient
+import net.minecraft.client.option.KeyBind
+import net.minecraft.item.ItemStack
+import net.minecraft.network.PacketByteBuf
+import org.lwjgl.glfw.GLFW
+
+object WRKeyBindings {
+    private var hotbarScrollEnabled = true
+    private var heldTooltipOffset = 0
+
+    // Wires + Buses (toggle)
+    private val mapWiresAndCables by lazy {
+        sequenceOf(INSULATED_WIRES, STANDING_INSULATED_WIRES, BUNDLED_CABLES, STANDING_BUNDLED_CABLES)
+            .plus(mapOf(null to RED_ALLOY_WIRE))
+            .plus(mapOf(null to STANDING_RED_ALLOY_WIRE))
+            .map { it.entries }.reduce { a, b -> a + b }
+            .associate {
+                it.value to sequenceOf(
+                    INSULATED_WIRES[it.key] ?: RED_ALLOY_WIRE,
+                    STANDING_INSULATED_WIRES[it.key] ?: STANDING_RED_ALLOY_WIRE,
+                    BUNDLED_CABLES[it.key]!!,
+                    STANDING_BUNDLED_CABLES[it.key]!!
+                )
+            }
+    }
+
+    // Keybindings
+    val TOGGLE_WIRE_STATE by lazy {
+        KeyBind(
+            "key.wiredredstone.toggle_wire_state",
+            InputUtil.Type.KEYSYM,
+            GLFW.GLFW_KEY_R,
+            "key.wiredredstone.mod_name"
+        )
+    }
+
+    fun init() {
+        KeyBindingHelper.registerKeyBinding(TOGGLE_WIRE_STATE)
+
+        // Scroll menu
+        MouseScrollListenerRegistry.registerListener { _, _, scrollDeltaY ->
+            if (hotbarScrollEnabled) return@registerListener
+
+            val client = MinecraftClient.getInstance()
+            val player = client.player ?: return@registerListener
+            val activeStack = player.mainHandStack
+            val wiresAndCables = mapWiresAndCables[activeStack.item]?.toList()
+
+            if (TOGGLE_WIRE_STATE.isPressed && wiresAndCables != null) {
+                val menuIndex = wiresAndCables.indexOf(activeStack.item)
+                var newIndex = menuIndex - scrollDeltaY.toInt()
+                if (newIndex < 0) newIndex = wiresAndCables.size - 1
+                if (newIndex >= wiresAndCables.size) newIndex = 0
+                val newItem = wiresAndCables[newIndex]
+
+                val newStack = ItemStack(newItem, activeStack.count)
+                newStack.nbt = activeStack.nbt
+
+                val buf = PacketByteBuf(Unpooled.buffer())
+                buf.writeInt(player.inventory.selectedSlot)
+                buf.writeItemStack(newStack)
+
+                ClientPlayNetworking.send(WRNetworking.INVENTORY_UPDATE_CHANNEL, buf)
+            }
+        }
+
+        // Render select list over hotbar
+        HudRenderCallback.EVENT.register { guiGraphics, _ ->
+            val player = MinecraftClient.getInstance().player ?: return@register
+            if (!player.isCreative) return@register
+            val activeItem = player.mainHandStack.item
+            val activeSlot = player.inventory.selectedSlot
+            val wiresAndCables = mapWiresAndCables[activeItem]?.toList()
+
+            if (TOGGLE_WIRE_STATE.isPressed && wiresAndCables != null) {
+                hotbarScrollEnabled = false
+                val menuIndex = wiresAndCables.indexOf(activeItem)
+
+                val hotbarX = guiGraphics.scaledWindowWidth / 2 - 91
+                val hotbarY = guiGraphics.scaledWindowHeight - 22
+
+                heldTooltipOffset = 12
+
+                wiresAndCables.forEachIndexed { index, item ->
+                    val itemStack = ItemStack(item)
+                    val x = hotbarX + (index + activeSlot - menuIndex) * 20 + 3
+                    val y = hotbarY - 20
+
+                    guiGraphics.drawItem(itemStack, x, y)
+                    if (index == menuIndex) guiGraphics.fill(x - 1, y - 1, x + 17, y + 17, -2130706433)
+                }
+            } else {
+                hotbarScrollEnabled = true
+                heldTooltipOffset = 0
+            }
+        }
+    }
+
+    @JvmStatic
+    fun isHotbarScrollEnabled(): Boolean {
+        return hotbarScrollEnabled
+    }
+
+    @JvmStatic
+    fun getHeldItemTooltipOffset(): Int {
+        return heldTooltipOffset
+    }
+}

--- a/src/main/kotlin/com/kneelawk/wiredredstone/net/WRNetworking.kt
+++ b/src/main/kotlin/com/kneelawk/wiredredstone/net/WRNetworking.kt
@@ -24,6 +24,7 @@ object WRNetworking {
 
     val HELLO_CHANNEL = id("hello")
     val CONFIG_SYNC_CHANNEL = id("config_sync")
+    val INVENTORY_UPDATE_CHANNEL = id("inventory_update")
 
     private val MISSING_MOD_LOGIN_TEXT = Text.literal("Client is missing Wired Redstone mod version >= 0.4.15")
     private val MISSING_MOD_PLAY_TEXT = Text.literal("Client is missing Wired Redstone mod version >= 0.4.16")
@@ -76,6 +77,12 @@ object WRNetworking {
                     }
                 }
             }
+        }
+
+        ServerPlayNetworking.registerGlobalReceiver(INVENTORY_UPDATE_CHANNEL) { _, player, handler, buf, _ ->
+            val slot = buf.readInt()
+            val itemStack = buf.readItemStack()
+            player.server.execute { player.inventory.setStack(slot, itemStack) }
         }
 
         ServerPlayConnectionEvents.DISCONNECT.register { handler, _ ->

--- a/src/main/resources/assets/wiredredstone/lang/en_us.json
+++ b/src/main/resources/assets/wiredredstone/lang/en_us.json
@@ -167,5 +167,9 @@
   "tag.wiredredstone.insulated_wires": "Insulated Wires",
   "tag.wiredredstone.colored_standing_bundled_cables": "Colored Standing Bundled Cables",
   "tag.wiredredstone.standing_insulated_wires": "Standing Insulated Wires",
-  "tag.wiredredstone.screwdrivers": "Screwdrivers"
+  "tag.wiredredstone.screwdrivers": "Screwdrivers",
+
+  "key.wiredredstone.mod_name": "Wired Redstone",
+  "key.wiredredstone.toggle_wire_state": "Toggle Wire State"
 }
+

--- a/src/main/resources/assets/wiredredstone/lang/ru_ru.json
+++ b/src/main/resources/assets/wiredredstone/lang/ru_ru.json
@@ -167,5 +167,8 @@
   "tag.wiredredstone.insulated_wires": "Изолированные провода",
   "tag.wiredredstone.colored_standing_bundled_cables": "Цветные постоянные связанные кабели",
   "tag.wiredredstone.standing_insulated_wires": "Постоянные изолированные провода",
-  "tag.wiredredstone.screwdrivers": "Отвертки"
+  "tag.wiredredstone.screwdrivers": "Отвертки",
+
+  "key.wiredredstone.mod_name": "Проводной редстоун",
+  "key.wiredredstone.toggle_wire_state": "Переключить состояние провода"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -61,6 +61,7 @@
     "fabricloader": ">=0.12.12",
     "fabric": "*",
     "fabric-language-kotlin": ">=1.8.1+kotlin.1.7.0",
+    "fabric-key-binding-api-v1": "*",
     "graphlib": "*",
     "libmultipart": ">=0.7.3-pre.3",
     "libnetworkstack": ">=0.6.0",

--- a/src/main/resources/wiredredstone.mixins.json
+++ b/src/main/resources/wiredredstone.mixins.json
@@ -8,6 +8,9 @@
   "client": [
     "ClientRecipeBookMixin",
     "GameRendererAccessor",
+    "InGameHudMixin",
+    "MouseMixin",
+    "PlayerInventoryMixin",
     "RenderLayerAccessor"
   ],
   "mixins": [


### PR DESCRIPTION
# Overview

This PR adds a new keybind for quick item switching: `[Standing] Insulated Wire`, `[Standing] Bundled Cable`. By default, it is set to the `R` key, but it can be reassigned in the settings:

![image](https://github.com/Kneelawk/WiredRedstone/assets/90126102/ab8e9af8-12ea-41ec-981e-53a4bccabd07)

## Interactivity

When this keybind is held, a HUD overlay is added with a selection of several options of the same color. Scroll with mouse in order to switch. This solves the issue of excessive variations of essentially the same functional block, which previously occupied more than 50 slots, now reduced to 17.

![image](https://github.com/Kneelawk/WiredRedstone/assets/90126102/cbdd13e2-a1ab-4e30-a9b2-70618a0d59d8)

This feature only works in creative mode, and the switching is cyclic.

# Technical Changes

- Item switching is done through an additional packet channel. [Link to code changes](https://github.com/ButterSus/WiredRedstone/commit/6fabe91af307796e77013bec6fc6697a2942f647?diff=unified&w=0#diff-86ffa8e2af0d9185ffb300487492e9c1e60d8a04c827fc83945c8f13e6d4a821).
- For capturing mouse scroll, [MouseMixin.java](https://github.com/ButterSus/WiredRedstone/commit/6fabe91af307796e77013bec6fc6697a2942f647?diff=unified&w=0#diff-4a931d53a1d00715b6d0eca070ed5fa315cd3b65d82aa05cc4f815ec7893e4c2) was written along with [MouseScrollListener.java](https://github.com/ButterSus/WiredRedstone/commit/6fabe91af307796e77013bec6fc6697a2942f647?diff=unified&w=0#diff-fbb7a90c03c9a9ff87be043725af6356d8217ff880465c605442ed72b03e833d), [MouseScrollListenerRegistry](https://github.com/ButterSus/WiredRedstone/commit/6fabe91af307796e77013bec6fc6697a2942f647?diff=unified&w=0#diff-99f1729d1da0e0ba4377add312ec888a7d45a26f42ae4641478701da7741d07e), and [PlayerInventoryMixin.java](https://github.com/ButterSus/WiredRedstone/commit/6fabe91af307796e77013bec6fc6697a2942f647?diff=unified&w=0#diff-fd82eff39bd459ddccb0613d5e787733fbf86538119d7a84d4a1eb7ddbce05c5) to disable hotbar switching.
- When the HUD overlay is enabled, the HeldItemTooltip is shifted (see image below), for which [InGameHudMixin.java](https://github.com/Kneelawk/WiredRedstone/pull/49/files#diff-be24c082f6e687f5dfdd94cd9d0e2d08c48b2ff8384e5deb163d138af5dd170b) was written.

![image](https://github.com/Kneelawk/WiredRedstone/assets/90126102/f56e49f5-edff-485c-97fa-ee16c8f38924)

- The implementation of the HUD overlay itself should ideally be reworked (in my opinion). [Link to implementation](https://github.com/ButterSus/WiredRedstone/commit/6fabe91af307796e77013bec6fc6697a2942f647?diff=unified&w=0#r143682024).
- Added names for two keybindings.

## Request
- Please review the sections where I have left comments, as I am not sure they align with the structure of your project.
- It's not hard to add color switching in the same way, I just haven't figured out how to make a grid in Layout yet.
